### PR TITLE
Fpfissupp 4598

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -31,7 +31,7 @@ pipeline:
     group: test
     image: fpfis/drone-plugin-packer
     commands:
-      - packer build -var Version=${DRONE_BUILD_NUMBER} -var profile=default -var AWS_AKI=$AWS_ACCESS_KEY_ID -var AWS_SAK=$AWS_SECRET_ACCESS_KEY test/aws.json
+      - packer build -var Version=${DRONE_BUILD_NUMBER} -var profile=default test/aws.json
     when:
       event: [ push , pull_request ]
       branch: [master]
@@ -40,7 +40,7 @@ pipeline:
     group: test
     image: fpfis/drone-plugin-packer
     commands:
-      - packer build -var Version=${DRONE_BUILD_NUMBER} -var profile=docker -var AWS_AKI=$AWS_ACCESS_KEY_ID -var AWS_SAK=$AWS_SECRET_ACCESS_KEY test/aws.json
+      - packer build -var Version=${DRONE_BUILD_NUMBER} -var profile=docker test/aws.json
     when:
       event: [ push , pull_request ]
       branch: [master]
@@ -49,7 +49,7 @@ pipeline:
     group: test
     image: fpfis/drone-plugin-packer
     commands:
-      - packer build -var Version=${DRONE_BUILD_NUMBER} -var profile=lamp-56 -var AWS_AKI=$AWS_ACCESS_KEY_ID -var AWS_SAK=$AWS_SECRET_ACCESS_KEY test/aws.json
+      - packer build -var Version=${DRONE_BUILD_NUMBER} -var profile=lamp-56 test/aws.json
     when:
       event: [ push , pull_request ]
       branch: [master]
@@ -59,7 +59,7 @@ pipeline:
     image: fpfis/drone-plugin-packer
     secrets: [ AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY ]
     commands:
-      - packer build -var Version=${DRONE_BUILD_NUMBER} -var profile=lamp-71 -var AWS_AKI=$AWS_ACCESS_KEY_ID -var AWS_SAK=$AWS_SECRET_ACCESS_KEY test/aws.json
+      - packer build -var Version=${DRONE_BUILD_NUMBER} -var profile=lamp-71 test/aws.json
     when:
       event: [ push , pull_request ]
       branch: [master]
@@ -68,7 +68,7 @@ pipeline:
     group: test
     image: fpfis/drone-plugin-packer
     commands:
-      - packer build -var Version=${DRONE_BUILD_NUMBER} -var profile=lamp-72 -var AWS_AKI=$AWS_ACCESS_KEY_ID -var AWS_SAK=$AWS_SECRET_ACCESS_KEY test/aws.json
+      - packer build -var Version=${DRONE_BUILD_NUMBER} -var profile=lamp-72 test/aws.json
     when:
       event: [ push , pull_request ]
       branch: [master]
@@ -77,7 +77,7 @@ pipeline:
     group: test
     image: fpfis/drone-plugin-packer
     commands:
-      - packer build -var Version=${DRONE_BUILD_NUMBER} -var profile=lamp-73 -var AWS_AKI=$AWS_ACCESS_KEY_ID -var AWS_SAK=$AWS_SECRET_ACCESS_KEY test/aws.json
+      - packer build -var Version=${DRONE_BUILD_NUMBER} -var profile=lamp-73 test/aws.json
     when:
       event: [ push , pull_request ]
       branch: [master]
@@ -87,7 +87,7 @@ pipeline:
     image: fpfis/drone-plugin-packer
     secrets: [ AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY ]
     commands:
-      - packer build -var Version=${DRONE_BUILD_NUMBER} -var instance=medium -var profile=lamp-multi-versions -var AWS_AKI=$AWS_ACCESS_KEY_ID -var AWS_SAK=$AWS_SECRET_ACCESS_KEY test/aws.json
+      - packer build -var Version=${DRONE_BUILD_NUMBER} -var instance=medium -var profile=lamp-multi-versions test/aws.json
     when:
       event: [ push , pull_request ]
       branch: [master]
@@ -96,7 +96,7 @@ pipeline:
     group: test
     image: fpfis/drone-plugin-packer
     commands:
-      - packer build -var Version=${DRONE_BUILD_NUMBER} -var instance=medium -var profile=webtools -var AWS_AKI=$AWS_ACCESS_KEY_ID -var AWS_SAK=$AWS_SECRET_ACCESS_KEY test/aws.json
+      - packer build -var Version=${DRONE_BUILD_NUMBER} -var instance=medium -var profile=webtools test/aws.json
     when:
       event: [ push , pull_request ]
       branch: [master]

--- a/.drone.yml
+++ b/.drone.yml
@@ -30,6 +30,7 @@ pipeline:
   test-default:
     group: test
     image: fpfis/drone-plugin-packer
+    secrets: [ AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY ]
     commands:
       - packer build -var Version=${DRONE_BUILD_NUMBER} -var profile=default test/aws.json
     when:
@@ -39,6 +40,7 @@ pipeline:
   test-docker:
     group: test
     image: fpfis/drone-plugin-packer
+    secrets: [ AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY ]
     commands:
       - packer build -var Version=${DRONE_BUILD_NUMBER} -var profile=docker test/aws.json
     when:
@@ -48,6 +50,7 @@ pipeline:
   test-lamp-56:
     group: test
     image: fpfis/drone-plugin-packer
+    secrets: [ AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY ]
     commands:
       - packer build -var Version=${DRONE_BUILD_NUMBER} -var profile=lamp-56 test/aws.json
     when:
@@ -67,6 +70,7 @@ pipeline:
   test-lamp-72:
     group: test
     image: fpfis/drone-plugin-packer
+    secrets: [ AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY ]
     commands:
       - packer build -var Version=${DRONE_BUILD_NUMBER} -var profile=lamp-72 test/aws.json
     when:
@@ -76,6 +80,7 @@ pipeline:
   test-lamp-73:
     group: test
     image: fpfis/drone-plugin-packer
+    secrets: [ AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY ]
     commands:
       - packer build -var Version=${DRONE_BUILD_NUMBER} -var profile=lamp-73 test/aws.json
     when:
@@ -95,6 +100,7 @@ pipeline:
   test-webtools:
     group: test
     image: fpfis/drone-plugin-packer
+    secrets: [ AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY ]
     commands:
       - packer build -var Version=${DRONE_BUILD_NUMBER} -var instance=medium -var profile=webtools test/aws.json
     when:

--- a/.drone.yml
+++ b/.drone.yml
@@ -30,7 +30,6 @@ pipeline:
   test-default:
     group: test
     image: fpfis/drone-plugin-packer
-    secrets: [ AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY ]
     commands:
       - packer build -var Version=${DRONE_BUILD_NUMBER} -var profile=default -var AWS_AKI=$AWS_ACCESS_KEY_ID -var AWS_SAK=$AWS_SECRET_ACCESS_KEY test/aws.json
     when:
@@ -40,7 +39,6 @@ pipeline:
   test-docker:
     group: test
     image: fpfis/drone-plugin-packer
-    secrets: [ AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY ]
     commands:
       - packer build -var Version=${DRONE_BUILD_NUMBER} -var profile=docker -var AWS_AKI=$AWS_ACCESS_KEY_ID -var AWS_SAK=$AWS_SECRET_ACCESS_KEY test/aws.json
     when:
@@ -50,7 +48,6 @@ pipeline:
   test-lamp-56:
     group: test
     image: fpfis/drone-plugin-packer
-    secrets: [ AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY ]
     commands:
       - packer build -var Version=${DRONE_BUILD_NUMBER} -var profile=lamp-56 -var AWS_AKI=$AWS_ACCESS_KEY_ID -var AWS_SAK=$AWS_SECRET_ACCESS_KEY test/aws.json
     when:
@@ -70,7 +67,6 @@ pipeline:
   test-lamp-72:
     group: test
     image: fpfis/drone-plugin-packer
-    secrets: [ AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY ]
     commands:
       - packer build -var Version=${DRONE_BUILD_NUMBER} -var profile=lamp-72 -var AWS_AKI=$AWS_ACCESS_KEY_ID -var AWS_SAK=$AWS_SECRET_ACCESS_KEY test/aws.json
     when:
@@ -80,7 +76,6 @@ pipeline:
   test-lamp-73:
     group: test
     image: fpfis/drone-plugin-packer
-    secrets: [ AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY ]
     commands:
       - packer build -var Version=${DRONE_BUILD_NUMBER} -var profile=lamp-73 -var AWS_AKI=$AWS_ACCESS_KEY_ID -var AWS_SAK=$AWS_SECRET_ACCESS_KEY test/aws.json
     when:
@@ -100,7 +95,6 @@ pipeline:
   test-webtools:
     group: test
     image: fpfis/drone-plugin-packer
-    secrets: [ AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY ]
     commands:
       - packer build -var Version=${DRONE_BUILD_NUMBER} -var instance=medium -var profile=webtools -var AWS_AKI=$AWS_ACCESS_KEY_ID -var AWS_SAK=$AWS_SECRET_ACCESS_KEY test/aws.json
     when:

--- a/salt/config/files/route53.service
+++ b/salt/config/files/route53.service
@@ -23,7 +23,7 @@ C9_ROLE_ARN="arn:aws:iam::469132580751:role/Cloud9Role"
 start()
 {
     echo -n "Starting $NAME..."
-    if [[ `curl -s http://169.254.169.254/latest/meta-data/iam/info` =~ instance-profile/Cloud9Role ]]
+    if [[ `curl -s http://169.254.169.254/latest/meta-data/iam/info` =~ instance-profile/Cloud9Role && `curl -s http://169.254.169.254/latest/meta-data/security-groups` =~ CLOUD9-COMMON-SG ]]
     then
         su $CHUSER -s /bin/bash -c "aws configure list --profile Cloud9Role" 2&>1 /dev/null || su $CHUSER -s /bin/bash -c "aws configure set region eu-west-1 --profile Cloud9Role" > /dev/null
         su $CHUSER -s /bin/bash -c "aws sts assume-role --role-arn ${C9_ROLE_ARN} --role-session-name Cloud9Role --profile Cloud9Role" > /dev/null

--- a/salt/config/files/set_minion_id.sh
+++ b/salt/config/files/set_minion_id.sh
@@ -3,7 +3,8 @@
 export HOME="/home/ec2-user"
 
 # Load Credentials for Cloud9Role
-aws sts assume-role --role-arn "arn:aws:iam::469132580751:role/Cloud9Role" --role-session-name Cloud9Role --profile Cloud9Role > /dev/null
+aws configure set region eu-west-1 --profile Cloud9Role
+aws sts assume-role --role-arn "arn:aws:iam::469132580751:role/Cloud9Role" --role-session-name Cloud9Role --profile Cloud9Role --duration-seconds 900 > /dev/null
 
 # Set minion_id
 AWS_INSTANCE_ID=$(curl -s http://169.254.169.254/latest/meta-data/instance-id)

--- a/salt/config/files/set_minion_id.sh
+++ b/salt/config/files/set_minion_id.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 
-sleep 60
-
 export HOME="/home/ec2-user"
+
+# Load Credentials for Cloud9Role
+aws sts assume-role --role-arn "arn:aws:iam::469132580751:role/Cloud9Role" --role-session-name Cloud9Role --profile Cloud9Role > /dev/null
 
 # Set minion_id
 AWS_INSTANCE_ID=$(curl -s http://169.254.169.254/latest/meta-data/instance-id)

--- a/salt/config/files/set_minion_id.sh
+++ b/salt/config/files/set_minion_id.sh
@@ -6,7 +6,7 @@ export HOME="/home/ec2-user"
 
 # Set minion_id
 AWS_INSTANCE_ID=$(curl -s http://169.254.169.254/latest/meta-data/instance-id)
-INSTANCE_NAME=$(aws ec2 describe-tags --filters "Name=resource-id,Values=$AWS_INSTANCE_ID" "Name=key,Values=Name" --output text | cut -f5)
+INSTANCE_NAME=$(aws ec2 describe-tags --filters "Name=resource-id,Values=$AWS_INSTANCE_ID" "Name=key,Values=Name" --profile Cloud9Role --output text | cut -f5)
 if [ "$INSTANCE_NAME" != "" ]; then
   echo "$INSTANCE_NAME-$AWS_INSTANCE_ID" | sudo tee /etc/salt/minion_id
 fi

--- a/salt/config/setSaltMinionID.sls
+++ b/salt/config/setSaltMinionID.sls
@@ -1,3 +1,8 @@
+setCloud9RoleProfile:
+  cmd.run:
+    - name: "aws configure set region eu-west-1 --profile Cloud9Role"
+    - runas:  ec2-user
+
 /home/ec2-user/environment/.c9/salt/set_minion_id.sh:
   file.managed:
     - source: salt://config/files/set_minion_id.sh

--- a/salt/config/setSaltMinionID.sls
+++ b/salt/config/setSaltMinionID.sls
@@ -1,8 +1,3 @@
-setCloud9RoleProfile:
-  cmd.run:
-    - name: "aws configure set region eu-west-1 --profile Cloud9Role"
-    - runas:  ec2-user
-
 /home/ec2-user/environment/.c9/salt/set_minion_id.sh:
   file.managed:
     - source: salt://config/files/set_minion_id.sh

--- a/salt/frp/init.sls
+++ b/salt/frp/init.sls
@@ -3,8 +3,8 @@
 # Get frp local name from EC2 instance tag 'Name'
 {% set instance_id = salt['cmd.run']('curl -s http://169.254.169.254/latest/meta-data/instance-id') %}
 
-{% salt['cmd.run']('aws configure set region eu-west-1 --profile Cloud9Role') %}
-{% salt['cmd.run']('aws sts assume-role --role-arn "arn:aws:iam::469132580751:role/Cloud9Role" --role-session-name Cloud9Role --profile Cloud9Role > /dev/null') %}
+{{ salt['cmd.run']('aws configure set region eu-west-1 --profile Cloud9Role') }}
+{% set devNull = salt['cmd.run']('aws sts assume-role --duration-seconds 900 --role-arn arn:aws:iam::469132580751:role/Cloud9Role --role-session-name Cloud9Role --profile Cloud9Role') %}
 {% set instance_name = salt['cmd.run']('aws ec2 describe-instances --instance-ids ' + instance_id + ' --profile Cloud9Role --output text --query \'Reservations[].Instances[].Tags[?Key==`Name`].Value[]\'', runas='ec2-user') %}
 {% set frp_name = instance_name | regex_replace('aws-cloud9-(.*)-[a-z0-9]{32}', '\\1', ignorecase=True)  %}
 

--- a/salt/frp/init.sls
+++ b/salt/frp/init.sls
@@ -2,6 +2,9 @@
 
 # Get frp local name from EC2 instance tag 'Name'
 {% set instance_id = salt['cmd.run']('curl -s http://169.254.169.254/latest/meta-data/instance-id') %}
+
+{% salt['cmd.run']('aws configure set region eu-west-1 --profile Cloud9Role') %}
+{% salt['cmd.run']('aws sts assume-role --role-arn "arn:aws:iam::469132580751:role/Cloud9Role" --role-session-name Cloud9Role --profile Cloud9Role > /dev/null') %}
 {% set instance_name = salt['cmd.run']('aws ec2 describe-instances --instance-ids ' + instance_id + ' --profile Cloud9Role --output text --query \'Reservations[].Instances[].Tags[?Key==`Name`].Value[]\'', runas='ec2-user') %}
 {% set frp_name = instance_name | regex_replace('aws-cloud9-(.*)-[a-z0-9]{32}', '\\1', ignorecase=True)  %}
 

--- a/salt/frp/init.sls
+++ b/salt/frp/init.sls
@@ -2,7 +2,7 @@
 
 # Get frp local name from EC2 instance tag 'Name'
 {% set instance_id = salt['cmd.run']('curl -s http://169.254.169.254/latest/meta-data/instance-id') %}
-{% set instance_name = salt['cmd.run']('aws ec2 describe-instances --instance-ids ' + instance_id + ' --output text --query \'Reservations[].Instances[].Tags[?Key==`Name`].Value[]\'', runas='ec2-user') %}
+{% set instance_name = salt['cmd.run']('aws ec2 describe-instances --instance-ids ' + instance_id + ' --profile Cloud9Role --output text --query \'Reservations[].Instances[].Tags[?Key==`Name`].Value[]\'', runas='ec2-user') %}
 {% set frp_name = instance_name | regex_replace('aws-cloud9-(.*)-[a-z0-9]{32}', '\\1', ignorecase=True)  %}
 
 create_frp_folder:

--- a/salt/frp/init.sls
+++ b/salt/frp/init.sls
@@ -3,8 +3,8 @@
 # Get frp local name from EC2 instance tag 'Name'
 {% set instance_id = salt['cmd.run']('curl -s http://169.254.169.254/latest/meta-data/instance-id') %}
 
-{{ salt['cmd.run']('aws configure set region eu-west-1 --profile Cloud9Role') }}
-{% set devNull = salt['cmd.run']('aws sts assume-role --duration-seconds 900 --role-arn arn:aws:iam::469132580751:role/Cloud9Role --role-session-name Cloud9Role --profile Cloud9Role') %}
+{{ salt['cmd.run']('aws configure set region eu-west-1 --profile Cloud9Role', runas='ec2-user') }}
+{% set devNull = salt['cmd.run']('aws sts assume-role --duration-seconds 900 --role-arn arn:aws:iam::469132580751:role/Cloud9Role --role-session-name Cloud9Role --profile Cloud9Role', runas='ec2-user') %}
 {% set instance_name = salt['cmd.run']('aws ec2 describe-instances --instance-ids ' + instance_id + ' --profile Cloud9Role --output text --query \'Reservations[].Instances[].Tags[?Key==`Name`].Value[]\'', runas='ec2-user') %}
 {% set frp_name = instance_name | regex_replace('aws-cloud9-(.*)-[a-z0-9]{32}', '\\1', ignorecase=True)  %}
 

--- a/test/aws-install-salt.sh
+++ b/test/aws-install-salt.sh
@@ -1,8 +1,8 @@
+#!/bin/sh -e
+
 # Install salt stack minion for local usage.
 # Script used by packer for testing.
 # (equivalent to install-minion-Cloud9.sh for developer)
-
-#!/bin/sh -x
 
 # Start FRP srv for test
 sleep 5
@@ -35,8 +35,8 @@ sudo grep -q "service: rh_service" /etc/salt/minion || echo -e "providers:\n  se
 sudo service salt-minion restart
 
 # Start default commands
-sudo salt-call state.apply commands.expandFS --local
-sudo salt-call state.apply --local
+sudo salt-call --retcode-passthrough  state.apply commands.expandFS --local
+sudo salt-call --retcode-passthrough  state.apply --local
 
 # Setup aws credentials for aws-cli usage
 mkdir -p ~/.aws

--- a/test/aws-install-salt.sh
+++ b/test/aws-install-salt.sh
@@ -42,13 +42,4 @@ sudo salt-call state.apply --local
 mkdir -p ~/.aws
 rm -Rf ~/.aws/credentials
 
-FILE="/home/ec2-user/.aws/credentials"
-/bin/cat <<EOM >$FILE
-[default]
-aws_access_key_id=$1
-aws_secret_access_key=$2
-region=eu-west-1
-EOM
-
-
 

--- a/test/aws.json
+++ b/test/aws.json
@@ -21,6 +21,7 @@
     "ami_name": "aws-cloud9-packer-build-{{user `profile`}}",
     "ami_description": "drone build {{user `Version`}}",
     "security_group_id" : "sg-004f43eec5a463676",
+    "iam_instance_profile" : "Cloud9Role",
     "run_tags": {
       "Name": "packer-build-{{user `profile`}}"
     }

--- a/test/aws.json
+++ b/test/aws.json
@@ -49,7 +49,7 @@
     {
       "type": "shell",
       "inline": [
-        "/tmp/aws-install-salt.sh {{user `AWS_AKI`}} {{user `AWS_SAK`}}"
+        "/tmp/aws-install-salt.sh"
       ]
     },
     {


### PR DESCRIPTION
Use "profile Cloud9Role" for all script who need to use aws-cli.
Tests: Use Cloud9Role in 
Tests: Add `#!/bin/sh -e` in aws-install-salt.sh to detect any problem on test install